### PR TITLE
Add stdin and summary-only modes to RadarNet CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.venv/
+.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # RadarNet
+
+RadarNet یک ابزار سبک برای امتیازدهی ریسک در شبکه‌های سرویس‌محور است.
+
+## Features
+
+- مدل typed برای تعریف `Network`، `Node` و `Service`
+- اعتبارسنجی ورودی (پورت، criticality، تکراری نبودن node id و port)
+- موتور امتیازدهی ریسک با خروجی severity (`low` تا `critical`)
+- CLI برای تحلیل فایل JSON با خروجی `text` یا `json`
+- قابلیت `--fail-on` برای CI (شکست دادن pipeline بر اساس شدت ریسک)
+- پشتیبانی از ورودی `stdin` با `-` و خروجی خلاصه با `--summary-only`
+
+## Quickstart
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+radarnet examples/sample-network.json
+radarnet examples/sample-network.json --format json
+cat examples/sample-network.json | radarnet - --format json --summary-only
+pytest -q
+```
+
+## CLI
+
+```bash
+radarnet <input.json|-> [--format text|json] [--summary-only] [--fail-on low|medium|high|critical]
+```
+
+- اگر `--fail-on high` بدهید و severity گزارش `high` یا `critical` باشد، کد خروجی 2 برمی‌گردد.
+- در صورت ورودی نامعتبر، CLI با پیام خطای واضح متوقف می‌شود.
+
+## JSON schema (simplified)
+
+```json
+{
+  "name": "network-name",
+  "nodes": [
+    {
+      "id": "node-id",
+      "role": "gateway|backend|...",
+      "services": [
+        {
+          "name": "https",
+          "port": 443,
+          "public": true,
+          "encrypted": true,
+          "authenticated": true,
+          "criticality": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+## License
+
+MIT

--- a/examples/sample-network.json
+++ b/examples/sample-network.json
@@ -1,0 +1,20 @@
+{
+  "name": "production-mesh",
+  "nodes": [
+    {
+      "id": "edge-1",
+      "role": "gateway",
+      "services": [
+        {"name": "https", "port": 443, "public": true, "encrypted": true, "authenticated": true, "criticality": 5},
+        {"name": "metrics", "port": 9100, "public": false, "encrypted": false, "authenticated": false, "criticality": 2}
+      ]
+    },
+    {
+      "id": "worker-3",
+      "role": "backend",
+      "services": [
+        {"name": "grpc", "port": 50051, "public": false, "encrypted": true, "authenticated": true, "criticality": 4}
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "radarnet"
+version = "0.1.0"
+description = "A tiny threat-surface radar for service networks"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "RadarNet Contributors"}]
+keywords = ["security", "network", "risk", "radar"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+]
+
+[project.scripts]
+radarnet = "radarnet.cli:main"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/radarnet/__init__.py
+++ b/src/radarnet/__init__.py
@@ -1,0 +1,14 @@
+"""RadarNet package."""
+
+from .model import Network, Node, Service, ValidationError
+from .risk import RiskReport, meets_severity_threshold, score_network
+
+__all__ = [
+    "Network",
+    "Node",
+    "Service",
+    "ValidationError",
+    "RiskReport",
+    "score_network",
+    "meets_severity_threshold",
+]

--- a/src/radarnet/cli.py
+++ b/src/radarnet/cli.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .model import Network, Node, Service, ValidationError
+from .risk import SEVERITY_ORDER, meets_severity_threshold, score_network
+
+
+def _load_network_from_json(data: dict[str, object], fallback_name: str) -> Network:
+    nodes = []
+    for node_data in data.get("nodes", []):
+        services = [Service(**svc) for svc in node_data.get("services", [])]
+        nodes.append(
+            Node(
+                id=node_data["id"],
+                role=node_data.get("role", "unknown"),
+                services=tuple(services),
+            )
+        )
+
+    return Network(name=data.get("name", fallback_name), nodes=tuple(nodes))
+
+
+def _load_network(input_ref: str) -> Network:
+    if input_ref == "-":
+        payload = json.load(sys.stdin)
+        return _load_network_from_json(payload, fallback_name="stdin-network")
+
+    path = Path(input_ref)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _load_network_from_json(payload, fallback_name=path.stem)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="RadarNet risk scorer")
+    parser.add_argument("input", help="Path to network JSON file or '-' for stdin")
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=SEVERITY_ORDER,
+        default=None,
+        help="Exit with code 2 if report severity is at or above this value",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Only print summary fields (hide findings)",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        report = score_network(_load_network(args.input))
+    except (ValidationError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        parser.error(f"Invalid input: {exc}")
+
+    if args.format == "json":
+        payload = report.to_dict()
+        if args.summary_only:
+            payload.pop("findings", None)
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(f"Network: {report.network_name}")
+        print(f"Score: {report.score}/{report.max_score} ({report.ratio:.2%})")
+        print(f"Severity: {report.severity}")
+        if report.findings and not args.summary_only:
+            print("Findings:")
+            for finding in report.findings:
+                print(f"- {finding}")
+
+    if args.fail_on and meets_severity_threshold(report, args.fail_on):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/radarnet/model.py
+++ b/src/radarnet/model.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class ValidationError(ValueError):
+    """Raised when the network model contains invalid values."""
+
+
+@dataclass(frozen=True)
+class Service:
+    """Represents a network-facing service on a host."""
+
+    name: str
+    port: int
+    public: bool = False
+    encrypted: bool = True
+    authenticated: bool = True
+    criticality: int = 3
+
+    def validate(self) -> None:
+        if not self.name.strip():
+            raise ValidationError("service.name must be non-empty")
+        if not (1 <= self.port <= 65535):
+            raise ValidationError(f"service.port must be between 1 and 65535, got {self.port}")
+        if not (1 <= self.criticality <= 5):
+            raise ValidationError(
+                f"service.criticality must be between 1 and 5, got {self.criticality}"
+            )
+
+
+@dataclass(frozen=True)
+class Node:
+    """A machine/application node in the network."""
+
+    id: str
+    role: str
+    services: tuple[Service, ...] = field(default_factory=tuple)
+
+    def validate(self) -> None:
+        if not self.id.strip():
+            raise ValidationError("node.id must be non-empty")
+        if not self.role.strip():
+            raise ValidationError(f"node[{self.id}].role must be non-empty")
+        seen_ports: set[int] = set()
+        for service in self.services:
+            service.validate()
+            if service.port in seen_ports:
+                raise ValidationError(
+                    f"node[{self.id}] contains duplicate port definition: {service.port}"
+                )
+            seen_ports.add(service.port)
+
+
+@dataclass(frozen=True)
+class Network:
+    """A collection of nodes assessed by RadarNet."""
+
+    name: str
+    nodes: tuple[Node, ...] = field(default_factory=tuple)
+
+    def validate(self) -> None:
+        if not self.name.strip():
+            raise ValidationError("network.name must be non-empty")
+        seen_ids: set[str] = set()
+        for node in self.nodes:
+            node.validate()
+            if node.id in seen_ids:
+                raise ValidationError(f"duplicate node id detected: {node.id}")
+            seen_ids.add(node.id)

--- a/src/radarnet/risk.py
+++ b/src/radarnet/risk.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from .model import Network, Node, Service
+
+
+@dataclass(frozen=True)
+class RiskReport:
+    network_name: str
+    score: int
+    max_score: int
+    severity: str
+    findings: tuple[str, ...]
+
+    @property
+    def ratio(self) -> float:
+        return 0.0 if self.max_score == 0 else round(self.score / self.max_score, 4)
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        data["ratio"] = self.ratio
+        return data
+
+
+SEVERITY_ORDER = ("low", "medium", "high", "critical")
+
+
+def _service_risk(service: Service) -> tuple[int, list[str]]:
+    score = 0
+    findings: list[str] = []
+
+    if service.public:
+        score += 3
+        findings.append(f"{service.name}:{service.port} is public")
+    if not service.encrypted:
+        score += 3
+        findings.append(f"{service.name}:{service.port} is unencrypted")
+    if not service.authenticated:
+        score += 2
+        findings.append(f"{service.name}:{service.port} has no authentication")
+
+    score += service.criticality
+    return score, findings
+
+
+def _node_risk(node: Node) -> tuple[int, list[str]]:
+    score = 0
+    findings: list[str] = []
+
+    for service in node.services:
+        service_score, service_findings = _service_risk(service)
+        score += service_score
+        findings.extend([f"[{node.id}] {finding}" for finding in service_findings])
+
+    if not node.services:
+        findings.append(f"[{node.id}] has no tracked services (visibility gap)")
+        score += 2
+
+    return score, findings
+
+
+def _severity(score: int, max_score: int) -> str:
+    ratio = 0 if max_score == 0 else score / max_score
+    if ratio >= 0.75:
+        return "critical"
+    if ratio >= 0.50:
+        return "high"
+    if ratio >= 0.25:
+        return "medium"
+    return "low"
+
+
+def score_network(network: Network) -> RiskReport:
+    network.validate()
+
+    findings: list[str] = []
+    score = 0
+    max_score = max(1, len(network.nodes) * 13)
+
+    for node in network.nodes:
+        node_score, node_findings = _node_risk(node)
+        score += node_score
+        findings.extend(node_findings)
+
+    severity = _severity(score, max_score)
+    return RiskReport(
+        network_name=network.name,
+        score=score,
+        max_score=max_score,
+        severity=severity,
+        findings=tuple(findings),
+    )
+
+
+def meets_severity_threshold(report: RiskReport, threshold: str) -> bool:
+    if threshold not in SEVERITY_ORDER:
+        raise ValueError(f"Invalid threshold '{threshold}'. Use one of: {', '.join(SEVERITY_ORDER)}")
+    return SEVERITY_ORDER.index(report.severity) >= SEVERITY_ORDER.index(threshold)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,115 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from radarnet.model import Network, Node, Service, ValidationError
+from radarnet.risk import meets_severity_threshold, score_network
+
+
+def test_score_network_generates_findings_for_unsecure_services():
+    network = Network(
+        name="demo",
+        nodes=(
+            Node(
+                id="api-1",
+                role="api",
+                services=(
+                    Service(
+                        name="http",
+                        port=80,
+                        public=True,
+                        encrypted=False,
+                        authenticated=False,
+                        criticality=5,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    report = score_network(network)
+
+    assert report.score > 0
+    assert report.severity in {"medium", "high", "critical"}
+    assert any("unencrypted" in finding for finding in report.findings)
+    assert any("no authentication" in finding for finding in report.findings)
+
+
+def test_empty_node_is_treated_as_visibility_gap():
+    network = Network(name="demo", nodes=(Node(id="db-1", role="db", services=()),))
+
+    report = score_network(network)
+
+    assert report.score >= 2
+    assert any("visibility gap" in finding for finding in report.findings)
+
+
+def test_invalid_port_raises_validation_error():
+    network = Network(
+        name="demo",
+        nodes=(Node(id="api-1", role="api", services=(Service(name="x", port=70000),)),),
+    )
+
+    with pytest.raises(ValidationError):
+        score_network(network)
+
+
+def test_threshold_comparison():
+    network = Network(name="tiny", nodes=(Node(id="a", role="r", services=(Service(name="s", port=1),)),))
+    report = score_network(network)
+    assert meets_severity_threshold(report, "low") is True
+
+
+def test_cli_json_output(tmp_path):
+    sample = {
+        "name": "n1",
+        "nodes": [
+            {
+                "id": "edge",
+                "role": "gateway",
+                "services": [{"name": "http", "port": 80, "public": True, "encrypted": False, "authenticated": False, "criticality": 5}],
+            }
+        ],
+    }
+    input_path = tmp_path / "network.json"
+    input_path.write_text(json.dumps(sample), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "radarnet.cli", str(input_path), "--format", "json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["network_name"] == "n1"
+    assert payload["severity"] in {"medium", "high", "critical"}
+
+
+def test_cli_supports_stdin_and_summary_only():
+    sample = {
+        "name": "stdin-net",
+        "nodes": [
+            {
+                "id": "edge",
+                "role": "gateway",
+                "services": [{"name": "http", "port": 80, "public": True, "encrypted": False, "authenticated": False, "criticality": 5}],
+            }
+        ],
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-m", "radarnet.cli", "-", "--format", "json", "--summary-only"],
+        input=json.dumps(sample),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["network_name"] == "stdin-net"
+    assert "findings" not in payload


### PR DESCRIPTION
### Motivation

- Improve CLI ergonomics so networks can be piped in and CI workflows can consume compact or structured output. 
- Provide a concise JSON/text summary mode to simplify downstream parsing and CI gating. 
- Harden the library with a clear model API and validation to avoid silent misconfiguration during scoring. 

### Description

- Add typed model and validation in `src/radarnet/model.py` with `Network`, `Node`, `Service`, and `ValidationError` and checks for empty fields, port ranges, criticality bounds, duplicate node ids, and duplicate ports per node. 
- Implement scoring and report helpers in `src/radarnet/risk.py` including `RiskReport`, `_service_risk`, `_node_risk`, `_severity`, `score_network`, and `meets_severity_threshold`. 
- Replace the CLI with `src/radarnet/cli.py` that supports `stdin` input when `input` is `-`, `--format text|json`, `--summary-only` to suppress findings, and `--fail-on` to return exit code `2` when severity meets the threshold. 
- Export public API in `src/radarnet/__init__.py`, add `examples/sample-network.json`, update `README.md` with usage and examples, and add project metadata in `pyproject.toml`. 
- Add and update tests in `tests/test_risk.py` to cover validation errors, threshold comparison, JSON CLI output, and the new `stdin + --summary-only` behavior. 

### Testing

- Installed package in editable mode with `python -m pip install -e .[dev]` and the install completed successfully. 
- Ran unit tests with `pytest -q` and all tests passed (`6 passed`). 
- Manually exercised the CLI: `radarnet examples/sample-network.json --summary-only` produced a compact text summary and `cat examples/sample-network.json | radarnet - --format json --summary-only` produced the expected JSON payload without `findings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af551d4c8832da8a8177b0cc07c3b)